### PR TITLE
Add simple Flask web interface for Amiibo League

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,79 @@
+from flask import Flask, render_template, request, redirect
+from models import db, Amiibo, Match
+import random
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///amiibo.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db.init_app(app)
+
+with app.app_context():
+    db.create_all()
+
+# Simple ELO update function
+K = 32
+
+def update_elo(winner: Amiibo, loser: Amiibo):
+    expected_win = 1 / (1 + 10 ** ((loser.current_elo - winner.current_elo)/400))
+    winner.current_elo += int(K * (1 - expected_win))
+    loser.current_elo += int(K * (0 - (1 - expected_win)))
+    if winner.current_elo > winner.peak_elo:
+        winner.peak_elo = winner.current_elo
+    if loser.current_elo > loser.peak_elo:
+        loser.peak_elo = loser.current_elo
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/leaderboard', methods=['GET'])
+def leaderboard():
+    amiibos = Amiibo.query.order_by(Amiibo.current_elo.desc()).all()
+    return render_template('leaderboard.html', amiibos=amiibos)
+
+@app.route('/add_amiibo', methods=['POST'])
+def add_amiibo():
+    name = request.form['name']
+    a = Amiibo(name=name)
+    db.session.add(a)
+    db.session.commit()
+    return redirect('/leaderboard')
+
+current_pairs = []
+
+@app.route('/tournament', methods=['GET'])
+def tournament():
+    pairs = [(Amiibo.query.get(p1), Amiibo.query.get(p2), Amiibo.query.get(w) if w else None) for p1, p2, w in current_pairs]
+    return render_template('tournament.html', pairs=pairs)
+
+@app.route('/start_tournament', methods=['POST'])
+def start_tournament():
+    global current_pairs
+    players = Amiibo.query.order_by(Amiibo.current_elo.desc()).limit(8).all()
+    random.shuffle(players)
+    current_pairs = []
+    for i in range(0, len(players), 2):
+        if i+1 < len(players):
+            current_pairs.append((players[i].id, players[i+1].id, None))
+    return redirect('/tournament')
+
+@app.route('/report_result', methods=['POST'])
+def report_result():
+    global current_pairs
+    p1 = int(request.form['player1'])
+    p2 = int(request.form['player2'])
+    winner = int(request.form['winner'])
+    a1 = Amiibo.query.get(p1)
+    a2 = Amiibo.query.get(p2)
+    win_obj = a1 if winner == p1 else a2
+    lose_obj = a2 if winner == p1 else a1
+    update_elo(win_obj, lose_obj)
+    match = Match(player1_id=p1, player2_id=p2, winner_id=winner)
+    db.session.add(match)
+    db.session.commit()
+    current_pairs = [ (pp1, pp2, w if (pp1, pp2) != (p1, p2) else winner) for pp1, pp2, w in current_pairs]
+    return redirect('/tournament')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,16 @@
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()
+
+class Amiibo(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), unique=True, nullable=False)
+    current_elo = db.Column(db.Integer, default=1500)
+    peak_elo = db.Column(db.Integer, default=1500)
+
+class Match(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    player1_id = db.Column(db.Integer, db.ForeignKey('amiibo.id'))
+    player2_id = db.Column(db.Integer, db.ForeignKey('amiibo.id'))
+    winner_id = db.Column(db.Integer, db.ForeignKey('amiibo.id'))
+    round_no = db.Column(db.Integer, default=1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+flask_sqlalchemy

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; margin: 2em; }
+nav a { margin-right: 1em; }
+leaderboard-table { border-collapse: collapse; }
+table, th, td { border: 1px solid #ccc; padding: 0.5em; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Amiibo League</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <nav>
+        <a href="/">Home</a> |
+        <a href="/leaderboard">Leaderboard</a> |
+        <a href="/tournament">Tournament</a>
+    </nav>
+    <hr>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Welcome to Amiibo League</h1>
+<p>Manage tournaments and view standings.</p>
+{% endblock %}

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Leaderboard</h1>
+<table>
+    <tr><th>Name</th><th>Current Elo</th><th>Peak Elo</th></tr>
+    {% for amiibo in amiibos %}
+    <tr>
+        <td>{{ amiibo.name }}</td>
+        <td>{{ amiibo.current_elo }}</td>
+        <td>{{ amiibo.peak_elo }}</td>
+    </tr>
+    {% endfor %}
+</table>
+<form method="post" action="/add_amiibo">
+    <h3>Add Amiibo</h3>
+    <input type="text" name="name" placeholder="Name" required>
+    <button type="submit">Add</button>
+</form>
+{% endblock %}

--- a/templates/tournament.html
+++ b/templates/tournament.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Tournament</h1>
+{% if pairs %}
+<table>
+    <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
+    {% for match in pairs %}
+    <tr>
+        <td>{{ match[0].name }}</td>
+        <td>{{ match[1].name }}</td>
+        <td>
+            {% if match[2] %}
+                {{ match[2].name }}
+            {% else %}
+                <form method="post" action="/report_result">
+                    <input type="hidden" name="player1" value="{{ match[0].id }}">
+                    <input type="hidden" name="player2" value="{{ match[1].id }}">
+                    <select name="winner" required>
+                        <option value="{{ match[0].id }}">{{ match[0].name }}</option>
+                        <option value="{{ match[1].id }}">{{ match[1].name }}</option>
+                    </select>
+                    <button type="submit">Submit</button>
+                </form>
+            {% endif %}
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{% else %}
+<p>No tournament in progress.</p>
+{% endif %}
+<form method="post" action="/start_tournament">
+    <button type="submit">Start New Tournament</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create Flask app and database models for Amiibo and matches
- add leaderboard showing current and peak Elo
- add simple tournament page with match reporting
- provide minimal styles and templates
- define requirements

## Testing
- `python -m py_compile app.py models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68585ead1470832a99f0f2b7e2932b37