### PR TITLE
Implement Swiss seeding for leagues

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 - 1 Champion
 	- 4-große Gruppen
-		- initialisierung durch schnelles Swiss (4 Runden, nicht Rating spezifisch)
+                - initialisierung durch schnelles Swiss (4 Runden, nicht Rating spezifisch)
+                - Swiss kann im Webinterface unter "Swiss" gestartet und gespielt werden
+                - Nach Abschluss der 4 Runden werden automatisch vier Ligen gebildet
 		- Erster steigt auf
 		- Letzter steigt ab
 		- ca. 91 Teilnehmer -> 91 / 4 = ~22-23

--- a/app.py
+++ b/app.py
@@ -23,6 +23,28 @@ def update_elo(winner: Amiibo, loser: Amiibo):
     if loser.current_elo > loser.peak_elo:
         loser.peak_elo = loser.current_elo
 
+def generate_swiss_pairs(players, previous_matches):
+    """Pair players for a Swiss round avoiding rematches."""
+    unpaired = players[:]
+    pairs = []
+    while len(unpaired) > 1:
+        p1 = unpaired.pop(0)
+        idx = None
+        for i, p2 in enumerate(unpaired):
+            if (p1.id, p2.id) not in previous_matches and (p2.id, p1.id) not in previous_matches:
+                idx = i
+                break
+        if idx is None:
+            p2 = unpaired.pop(0)
+        else:
+            p2 = unpaired.pop(idx)
+        pairs.append((p1.id, p2.id, None))
+    # bye if odd number of players
+    if unpaired:
+        bye = unpaired.pop(0)
+        swiss_scores[bye.id] += 1
+    return pairs
+
 @app.route('/')
 def index():
     return render_template('index.html')
@@ -41,6 +63,10 @@ def add_amiibo():
     return redirect('/leaderboard')
 
 current_pairs = []
+current_swiss_pairs = []
+swiss_round = 0
+swiss_scores = {}
+swiss_previous_matches = set()
 
 @app.route('/tournament', methods=['GET'])
 def tournament():
@@ -74,6 +100,64 @@ def report_result():
     db.session.commit()
     current_pairs = [ (pp1, pp2, w if (pp1, pp2) != (p1, p2) else winner) for pp1, pp2, w in current_pairs]
     return redirect('/tournament')
+
+
+@app.route('/swiss', methods=['GET'])
+def swiss():
+    pairs = [(Amiibo.query.get(p1), Amiibo.query.get(p2), Amiibo.query.get(w) if w else None) for p1, p2, w in current_swiss_pairs]
+    players = Amiibo.query.all()
+    ordered = sorted(players, key=lambda a: swiss_scores.get(a.id, 0), reverse=True)
+    done = swiss_round > 4
+    current_round = min(swiss_round, 4)
+    return render_template('swiss.html', pairs=pairs, players=ordered, scores=swiss_scores, round_no=current_round, done=done)
+
+
+@app.route('/start_swiss', methods=['POST'])
+def start_swiss():
+    global current_swiss_pairs, swiss_round, swiss_scores, swiss_previous_matches
+    players = Amiibo.query.order_by(Amiibo.current_elo.desc()).all()
+    swiss_round = 1
+    swiss_scores = {p.id: 0 for p in players}
+    swiss_previous_matches = set()
+    current_swiss_pairs = generate_swiss_pairs(players, swiss_previous_matches)
+    return redirect('/swiss')
+
+
+@app.route('/report_swiss_result', methods=['POST'])
+def report_swiss_result():
+    global current_swiss_pairs, swiss_scores, swiss_round, swiss_previous_matches
+    p1 = int(request.form['player1'])
+    p2 = int(request.form['player2'])
+    winner = int(request.form['winner'])
+    a1 = Amiibo.query.get(p1)
+    a2 = Amiibo.query.get(p2)
+    win_obj = a1 if winner == p1 else a2
+    lose_obj = a2 if winner == p1 else a1
+    update_elo(win_obj, lose_obj)
+    match = Match(player1_id=p1, player2_id=p2, winner_id=winner, round_no=swiss_round)
+    db.session.add(match)
+    db.session.commit()
+    swiss_scores[winner] += 1
+    swiss_previous_matches.add((p1, p2))
+    current_swiss_pairs = [ (pp1, pp2, w if (pp1, pp2) != (p1, p2) else winner) for pp1, pp2, w in current_swiss_pairs]
+
+    if all(w for _,_,w in current_swiss_pairs):
+        if swiss_round >= 4:
+            swiss_round += 1
+            players = sorted(Amiibo.query.all(), key=lambda a: swiss_scores.get(a.id, 0), reverse=True)
+            total = len(players)
+            per_group = (total + 3) // 4
+            groups = ['A', 'B', 'C', 'D']
+            for idx, p in enumerate(players):
+                gi = min(idx // per_group, 3)
+                p.league = groups[gi]
+            db.session.commit()
+            current_swiss_pairs = []
+        else:
+            swiss_round += 1
+            players = sorted(Amiibo.query.all(), key=lambda a: (-swiss_scores.get(a.id, 0), a.current_elo))
+            current_swiss_pairs = generate_swiss_pairs(players, swiss_previous_matches)
+    return redirect('/swiss')
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/models.py
+++ b/models.py
@@ -7,6 +7,7 @@ class Amiibo(db.Model):
     name = db.Column(db.String(80), unique=True, nullable=False)
     current_elo = db.Column(db.Integer, default=1500)
     peak_elo = db.Column(db.Integer, default=1500)
+    league = db.Column(db.String(20), default="")
 
 class Match(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,8 @@
     <nav>
         <a href="/">Home</a> |
         <a href="/leaderboard">Leaderboard</a> |
-        <a href="/tournament">Tournament</a>
+        <a href="/tournament">Tournament</a> |
+        <a href="/swiss">Swiss</a>
     </nav>
     <hr>
     {% block content %}{% endblock %}

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -2,12 +2,13 @@
 {% block content %}
 <h1>Leaderboard</h1>
 <table>
-    <tr><th>Name</th><th>Current Elo</th><th>Peak Elo</th></tr>
+    <tr><th>Name</th><th>Current Elo</th><th>Peak Elo</th><th>League</th></tr>
     {% for amiibo in amiibos %}
     <tr>
         <td>{{ amiibo.name }}</td>
         <td>{{ amiibo.current_elo }}</td>
         <td>{{ amiibo.peak_elo }}</td>
+        <td>{{ amiibo.league }}</td>
     </tr>
     {% endfor %}
 </table>

--- a/templates/swiss.html
+++ b/templates/swiss.html
@@ -1,0 +1,50 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Initial Swiss</h1>
+{% if scores %}
+<h2>Round {{ round_no }}</h2>
+<table>
+    <tr><th>Name</th><th>Score</th><th>League</th></tr>
+    {% for p in players %}
+    <tr>
+        <td>{{ p.name }}</td>
+        <td>{{ scores[p.id] }}</td>
+        <td>{{ p.league }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% if pairs %}
+<table>
+    <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
+    {% for match in pairs %}
+    <tr>
+        <td>{{ match[0].name }}</td>
+        <td>{{ match[1].name }}</td>
+        <td>
+            {% if match[2] %}
+                {{ match[2].name }}
+            {% else %}
+                <form method="post" action="/report_swiss_result">
+                    <input type="hidden" name="player1" value="{{ match[0].id }}">
+                    <input type="hidden" name="player2" value="{{ match[1].id }}">
+                    <select name="winner" required>
+                        <option value="{{ match[0].id }}">{{ match[0].name }}</option>
+                        <option value="{{ match[1].id }}">{{ match[1].name }}</option>
+                    </select>
+                    <button type="submit">Submit</button>
+                </form>
+            {% endif %}
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{% else %}
+    {% if done %}<p>Swiss finished. Leagues assigned.</p>{% else %}<p>Round complete.</p>{% endif %}
+{% endif %}
+{% else %}
+<p>No Swiss in progress.</p>
+<form method="post" action="/start_swiss">
+    <button type="submit">Start Swiss</button>
+</form>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- create league column for Amiibo
- add Swiss tournament system with four rounds
- show leagues on leaderboard
- add Swiss page and navigation link
- document Swiss usage in README

## Testing
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_6858606777f0832a9ad391de12768fec