### PR TITLE
Implement league grouping and matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 	- 4-große Gruppen
                 - initialisierung durch schnelles Swiss (4 Runden, nicht Rating spezifisch)
                 - Swiss kann im Webinterface unter "Swiss" gestartet und gespielt werden
-                - Nach Abschluss der 4 Runden werden automatisch vier Ligen gebildet
+                - Nach Abschluss der 4 Runden werden automatisch Ligen mit je vier Spielern gebildet (die letzte Liga kann größer sein)
 		- Erster steigt auf
 		- Letzter steigt ab
 		- ca. 91 Teilnehmer -> 91 / 4 = ~22-23

--- a/app.py
+++ b/app.py
@@ -67,6 +67,8 @@ current_swiss_pairs = []
 swiss_round = 0
 swiss_scores = {}
 swiss_previous_matches = set()
+league_matches = {}
+league_scores = {}
 
 @app.route('/tournament', methods=['GET'])
 def tournament():
@@ -146,18 +148,69 @@ def report_swiss_result():
             swiss_round += 1
             players = sorted(Amiibo.query.all(), key=lambda a: swiss_scores.get(a.id, 0), reverse=True)
             total = len(players)
-            per_group = (total + 3) // 4
-            groups = ['A', 'B', 'C', 'D']
+            num_groups = (total + 3) // 4
+            groups = [chr(ord('A') + i) for i in range(num_groups)]
+            league_matches.clear()
+            league_scores.clear()
             for idx, p in enumerate(players):
-                gi = min(idx // per_group, 3)
-                p.league = groups[gi]
+                gi = idx // 4
+                if gi >= num_groups:
+                    gi = num_groups - 1
+                league = groups[gi]
+                p.league = league
+                league_scores.setdefault(league, {})[p.id] = 0
             db.session.commit()
+            for league in groups:
+                players_in_league = [pl for pl in players if pl.league == league]
+                matches = []
+                for i in range(len(players_in_league)):
+                    for j in range(i+1, len(players_in_league)):
+                        matches.append((players_in_league[i].id, players_in_league[j].id, None))
+                league_matches[league] = matches
             current_swiss_pairs = []
         else:
             swiss_round += 1
             players = sorted(Amiibo.query.all(), key=lambda a: (-swiss_scores.get(a.id, 0), a.current_elo))
             current_swiss_pairs = generate_swiss_pairs(players, swiss_previous_matches)
     return redirect('/swiss')
+
+
+@app.route('/league', methods=['GET'])
+def league():
+    displays = []
+    for lg in sorted(league_scores.keys()):
+        players = [(Amiibo.query.get(pid), score) for pid, score in league_scores[lg].items()]
+        players.sort(key=lambda x: x[1], reverse=True)
+        matches = [
+            (Amiibo.query.get(p1), Amiibo.query.get(p2), Amiibo.query.get(w) if w else None)
+            for p1, p2, w in league_matches.get(lg, [])
+        ]
+        displays.append((lg, players, matches))
+    return render_template('league.html', leagues=displays)
+
+
+@app.route('/report_league_result', methods=['POST'])
+def report_league_result():
+    league = request.form['league']
+    p1 = int(request.form['player1'])
+    p2 = int(request.form['player2'])
+    winner = int(request.form['winner'])
+    a1 = Amiibo.query.get(p1)
+    a2 = Amiibo.query.get(p2)
+    win_obj = a1 if winner == p1 else a2
+    lose_obj = a2 if winner == p1 else a1
+    update_elo(win_obj, lose_obj)
+    matches = league_matches.get(league, [])
+    for idx, m in enumerate(matches):
+        if (m[0], m[1]) == (p1, p2):
+            matches[idx] = (p1, p2, winner)
+            break
+    league_matches[league] = matches
+    league_scores[league][winner] += 1
+    match = Match(player1_id=p1, player2_id=p2, winner_id=winner, round_no=swiss_round)
+    db.session.add(match)
+    db.session.commit()
+    return redirect('/league')
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,7 +10,8 @@
         <a href="/">Home</a> |
         <a href="/leaderboard">Leaderboard</a> |
         <a href="/tournament">Tournament</a> |
-        <a href="/swiss">Swiss</a>
+        <a href="/swiss">Swiss</a> |
+        <a href="/league">League</a>
     </nav>
     <hr>
     {% block content %}{% endblock %}

--- a/templates/league.html
+++ b/templates/league.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Leagues</h1>
+{% for lg, players, matches in leagues %}
+<h2>League {{ lg }}</h2>
+<table>
+  <tr><th>Name</th><th>Wins</th></tr>
+  {% for p, sc in players %}
+  <tr><td>{{ p.name }}</td><td>{{ sc }}</td></tr>
+  {% endfor %}
+</table>
+<table>
+  <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
+  {% for m in matches %}
+  <tr>
+    <td>{{ m[0].name }}</td>
+    <td>{{ m[1].name }}</td>
+    <td>
+      {% if m[2] %}
+        {{ m[2].name }}
+      {% else %}
+        <form method="post" action="/report_league_result">
+            <input type="hidden" name="league" value="{{ lg }}">
+            <input type="hidden" name="player1" value="{{ m[0].id }}">
+            <input type="hidden" name="player2" value="{{ m[1].id }}">
+            <select name="winner" required>
+                <option value="{{ m[0].id }}">{{ m[0].name }}</option>
+                <option value="{{ m[1].id }}">{{ m[1].name }}</option>
+            </select>
+            <button type="submit">Submit</button>
+        </form>
+      {% endif %}
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+{% endfor %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- form leagues of 4 players at end of Swiss stage
- create league pairings and scores
- add `/league` view with result reporting
- link league page in navigation
- update README to describe new league setup

## Testing
- `python -m py_compile app.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_685862c045f0832aa8434e98a9079252