### PR TITLE
Add title logic and polished leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@
 Ziel: Alle Spielen weiterspielen, gleiche / ähnliche Anzahl spiele für Elo auswertung
 
 | Amiibo | Elo | Titel |
-|---------|--------| - |
-| Test 1 | 1200 | FM (Rentner) |
-| Test 2 | 1100 | NONE |
-| ... | ... | ... |
+|--------|-----|-------|
+| Test 1 | 1800 | FM |
+| Test 2 | 1950 | IM |
+| Test 3 | 2100 | GM |
 
 Die Leaderboard-Ansicht zeigt zusätzlich die gewonnenen "KoSieg"-Titel an.
 
@@ -53,8 +53,14 @@ Glicko 2 Elosystem (evtl. erweitert durch größe der Siege)
 
 
 ### Titel
-- FM (ab 1800 & 1 K.O. Win & gewisse Höhe von K.O)  
-- IM (ab 2000 & 2 K.O. Win & gewisse Höhe von K.O)
-- GM (ab 2200 & 3 K.O. Win & gewisse Höhe von K.O)
-Entsprechend anpassbar falls unrealistisch
-Titel kann nicht verloren werden bei Unterschreitung der Grenze
+Die Titel orientieren sich am Elo sowie an gewonnenen K.O.-Bracket­uellen.
+Es wird immer nur der höchste erreichte Titel angezeigt.
+
+- **FM** – ab 1800 Elo und mindestens **ein** Sieg in einem Bracket
+  der Klassen **EF** oder höher (also EF, CD oder AB).
+- **IM** – ab 1900 Elo und mindestens **zwei** Siege in Brackets der
+  Klassen **CD** oder höher.
+- **GM** – ab 2000 Elo und mindestens **drei** Siege im obersten Bracket
+  **AB**.
+
+Titel gehen bei Elo-Verlust nicht verloren.

--- a/models.py
+++ b/models.py
@@ -10,6 +10,28 @@ class Amiibo(db.Model):
     league = db.Column(db.String(20), default="")
     ko_titles = db.Column(db.String(120), default="")
 
+    @property
+    def title(self) -> str:
+        """Return the highest achieved title according to Elo and KO wins."""
+        def bracket_level(bracket: str) -> int:
+            letters = [ord(c.upper()) - 65 for c in bracket if c.isalpha()]
+            return min(letters) if letters else 100
+
+        wins = [b.strip() for b in self.ko_titles.split(',') if b.strip()]
+        levels = [bracket_level(b) for b in wins]
+
+        gm = self.peak_elo >= 2000 and sum(1 for l in levels if l <= bracket_level('A')) >= 3
+        im = self.peak_elo >= 1900 and sum(1 for l in levels if l <= bracket_level('C')) >= 2
+        fm = self.peak_elo >= 1800 and any(l <= bracket_level('E') for l in levels)
+
+        if gm:
+            return "GM"
+        if im:
+            return "IM"
+        if fm:
+            return "FM"
+        return ""
+
 class Match(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     player1_id = db.Column(db.Integer, db.ForeignKey('amiibo.id'))

--- a/static/style.css
+++ b/static/style.css
@@ -1,4 +1,36 @@
-body { font-family: Arial, sans-serif; margin: 2em; }
-nav a { margin-right: 1em; }
-leaderboard-table { border-collapse: collapse; }
-table, th, td { border: 1px solid #ccc; padding: 0.5em; }
+body {
+    font-family: Arial, sans-serif;
+    margin: 2em;
+    background-color: #f9f9f9;
+    color: #333;
+}
+
+nav {
+    margin-bottom: 1em;
+}
+
+nav a {
+    margin-right: 1em;
+    text-decoration: none;
+    color: #333;
+}
+
+nav a:hover {
+    text-decoration: underline;
+}
+
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-bottom: 1em;
+}
+
+th {
+    background-color: #eee;
+}
+
+table, th, td {
+    border: 1px solid #ccc;
+    padding: 0.5em;
+    text-align: left;
+}

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -1,11 +1,12 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Leaderboard</h1>
-<table>
-    <tr><th>Name</th><th>Current Elo</th><th>Peak Elo</th><th>League</th><th>KO Titles</th></tr>
+<table class="leaderboard">
+    <tr><th>Name</th><th>Title</th><th>Current Elo</th><th>Peak Elo</th><th>League</th><th>KO Titles</th></tr>
     {% for amiibo in amiibos %}
     <tr>
         <td>{{ amiibo.name }}</td>
+        <td>{{ amiibo.title }}</td>
         <td>{{ amiibo.current_elo }}</td>
         <td>{{ amiibo.peak_elo }}</td>
         <td>{{ amiibo.league }}</td>


### PR DESCRIPTION
## Summary
- document new title requirements in README
- determine player title from Elo and KO wins
- show titles on the leaderboard
- improve default stylesheet for a cleaner look

## Testing
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_68586a7ce3b0832a933f4d73ecdd55d0