### PR TITLE
Add dark mode toggle

### DIFF
--- a/static/darkmode.js
+++ b/static/darkmode.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const toggle = document.getElementById('theme-toggle');
+    if (!toggle) return;
+    const saved = localStorage.getItem('darkmode');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (saved === 'true' || (saved === null && prefersDark)) {
+        document.body.classList.add('dark-mode');
+    }
+    toggle.addEventListener('click', function() {
+        document.body.classList.toggle('dark-mode');
+        localStorage.setItem('darkmode', document.body.classList.contains('dark-mode'));
+    });
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,8 +1,16 @@
+:root {
+    --bg-color: #f9f9f9;
+    --text-color: #333;
+    --link-color: #333;
+    --header-bg: #eee;
+    --border-color: #ccc;
+}
+
 body {
     font-family: Arial, sans-serif;
     margin: 2em;
-    background-color: #f9f9f9;
-    color: #333;
+    background-color: var(--bg-color);
+    color: var(--text-color);
 }
 
 nav {
@@ -12,11 +20,15 @@ nav {
 nav a {
     margin-right: 1em;
     text-decoration: none;
-    color: #333;
+    color: var(--link-color);
 }
 
 nav a:hover {
     text-decoration: underline;
+}
+
+button.theme-toggle {
+    margin-left: 1em;
 }
 
 table {
@@ -26,11 +38,19 @@ table {
 }
 
 th {
-    background-color: #eee;
+    background-color: var(--header-bg);
 }
 
 table, th, td {
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     padding: 0.5em;
     text-align: left;
+}
+
+body.dark-mode {
+    --bg-color: #121212;
+    --text-color: #eee;
+    --link-color: #ddd;
+    --header-bg: #333;
+    --border-color: #555;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,8 +13,10 @@
         <a href="/swiss">Swiss</a> |
         <a href="/league">League</a> |
         <a href="/knockout">Knockout</a>
+        <button id="theme-toggle" class="theme-toggle">Dark Mode</button>
     </nav>
     <hr>
     {% block content %}{% endblock %}
+    <script src="/static/darkmode.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add dark theme styles and toggle button
- include simple JavaScript for storing preference

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68586e9e8e84832a8b51748ed13fd205