### PR TITLE
Handle mid-season amiibo joins

### DIFF
--- a/models.py
+++ b/models.py
@@ -9,6 +9,7 @@ class Amiibo(db.Model):
     peak_elo = db.Column(db.Integer, default=1500)
     league = db.Column(db.String(20), default="")
     ko_titles = db.Column(db.String(120), default="")
+    waiting = db.Column(db.Boolean, default=False)
 
     @property
     def title(self) -> str:


### PR DESCRIPTION
## Summary
- add `waiting` flag to Amiibo model
- mark newly added Amiibo as waiting if the league cycle is running
- append waiting Amiibo to the last league (or new league) when starting a new season
- exclude waiting Amiibo from promotion, relegation and knockout phases
- ensure the database has the new column on startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68586f6a70d8832a8fa5637b883f497e