### PR TITLE
Fix league assignment when adding new Amiibo

### DIFF
--- a/app.py
+++ b/app.py
@@ -63,7 +63,23 @@ def leaderboard():
 @app.route('/add_amiibo', methods=['POST'])
 def add_amiibo():
     name = request.form['name']
-    a = Amiibo(name=name, waiting=league_cycle_running())
+    cycle = league_cycle_running()
+    a = Amiibo(name=name, waiting=cycle)
+    if not cycle:
+        players = Amiibo.query.filter_by(waiting=False).all()
+        groups = sorted(set(p.league for p in players if p.league))
+        if not groups:
+            target = 'A'
+            size = 0
+        else:
+            last = groups[-1]
+            size = sum(1 for p in players if p.league == last)
+            if size >= 4:
+                target = chr(ord(last) + 1)
+                size = 0
+            else:
+                target = last
+        a.league = target
     db.session.add(a)
     db.session.commit()
     return redirect('/leaderboard')


### PR DESCRIPTION
## Summary
- immediately slot newly added Amiibo into an existing league when no
  tournament cycle is running
- create a new league only when the last league is full

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68587141c574832a9f276b94f0518b8f