### PR TITLE
Add logo rendering

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, redirect
+from flask import Flask, render_template, request, redirect, send_from_directory
 from sqlalchemy import text
 from models import db, Amiibo, Match
 import random
@@ -17,6 +17,11 @@ with app.app_context():
     except Exception:
         db.session.execute(text('ALTER TABLE amiibo ADD COLUMN waiting BOOLEAN DEFAULT 0'))
         db.session.commit()
+
+@app.route('/logo/<path:filename>')
+def serve_logo(filename):
+    """Serve images from the logo directory."""
+    return send_from_directory('logo', filename)
 
 # Simple ELO update function
 K = 32

--- a/static/style.css
+++ b/static/style.css
@@ -17,6 +17,12 @@ nav {
     margin-bottom: 1em;
 }
 
+nav img.logo {
+    height: 40px;
+    vertical-align: middle;
+    margin-right: 1em;
+}
+
 nav a {
     margin-right: 1em;
     text-decoration: none;

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
 </head>
 <body>
     <nav>
+        <img src="/logo/logo_standard.png" alt="Amiibo League Logo" class="logo">
         <a href="/">Home</a> |
         <a href="/leaderboard">Leaderboard</a> |
         <a href="/tournament">Tournament</a> |


### PR DESCRIPTION
## Summary
- display logo in navigation bar
- serve logo files from new Flask route
- style the logo image

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685875f04074832ab3c891101b3a3996