### PR TITLE
Enable draws and win percentage

### DIFF
--- a/templates/knockout.html
+++ b/templates/knockout.html
@@ -12,7 +12,11 @@
       <td>{{ m[1].name }}</td>
       <td>
         {% if m[2] %}
-          {{ m[2].name }}
+          {% if m[2] == 'Draw' %}
+            Draw
+          {% else %}
+            {{ m[2].name }}
+          {% endif %}
         {% else %}
           <form method="post" action="/report_knockout_result">
             <input type="hidden" name="bracket" value="{{ key }}">
@@ -21,6 +25,7 @@
             <select name="winner" required>
               <option value="{{ m[0].id }}">{{ m[0].name }}</option>
               <option value="{{ m[1].id }}">{{ m[1].name }}</option>
+              <option value="draw">Draw</option>
             </select>
             <button type="submit">Submit</button>
           </form>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -1,8 +1,13 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Leaderboard</h1>
+<form method="get" action="/leaderboard">
+    <label>Win% over last</label>
+    <input type="number" name="last" min="1" value="{{ last or '' }}">
+    <button type="submit">Apply</button>
+</form>
 <table class="leaderboard">
-    <tr><th>Name</th><th>Title</th><th>Current Elo</th><th>Peak Elo</th><th>League</th><th>KO Titles</th></tr>
+    <tr><th>Name</th><th>Title</th><th>Current Elo</th><th>Peak Elo</th><th>League</th><th>KO Titles</th><th>Win %</th></tr>
     {% for amiibo in amiibos %}
     <tr>
         <td>{{ amiibo.name }}</td>
@@ -11,6 +16,7 @@
         <td>{{ amiibo.peak_elo }}</td>
         <td>{{ amiibo.league }}</td>
         <td>{{ amiibo.ko_titles }}</td>
+        <td>{{ amiibo.win_percentage(last)|round(1) }}</td>
     </tr>
     {% endfor %}
 </table>

--- a/templates/league.html
+++ b/templates/league.html
@@ -17,7 +17,11 @@
     <td>{{ m[1].name }}</td>
     <td>
       {% if m[2] %}
-        {{ m[2].name }}
+        {% if m[2] == 'Draw' %}
+          Draw
+        {% else %}
+          {{ m[2].name }}
+        {% endif %}
       {% else %}
         <form method="post" action="/report_league_result">
             <input type="hidden" name="league" value="{{ lg }}">
@@ -26,6 +30,7 @@
             <select name="winner" required>
                 <option value="{{ m[0].id }}">{{ m[0].name }}</option>
                 <option value="{{ m[1].id }}">{{ m[1].name }}</option>
+                <option value="draw">Draw</option>
             </select>
             <button type="submit">Submit</button>
         </form>

--- a/templates/swiss.html
+++ b/templates/swiss.html
@@ -22,7 +22,11 @@
         <td>{{ match[1].name }}</td>
         <td>
             {% if match[2] %}
-                {{ match[2].name }}
+                {% if match[2] == 'Draw' %}
+                    Draw
+                {% else %}
+                    {{ match[2].name }}
+                {% endif %}
             {% else %}
                 <form method="post" action="/report_swiss_result">
                     <input type="hidden" name="player1" value="{{ match[0].id }}">
@@ -30,6 +34,7 @@
                     <select name="winner" required>
                         <option value="{{ match[0].id }}">{{ match[0].name }}</option>
                         <option value="{{ match[1].id }}">{{ match[1].name }}</option>
+                        <option value="draw">Draw</option>
                     </select>
                     <button type="submit">Submit</button>
                 </form>

--- a/templates/tournament.html
+++ b/templates/tournament.html
@@ -10,7 +10,11 @@
         <td>{{ match[1].name }}</td>
         <td>
             {% if match[2] %}
-                {{ match[2].name }}
+                {% if match[2] == 'Draw' %}
+                    Draw
+                {% else %}
+                    {{ match[2].name }}
+                {% endif %}
             {% else %}
                 <form method="post" action="/report_result">
                     <input type="hidden" name="player1" value="{{ match[0].id }}">
@@ -18,6 +22,7 @@
                     <select name="winner" required>
                         <option value="{{ match[0].id }}">{{ match[0].name }}</option>
                         <option value="{{ match[1].id }}">{{ match[1].name }}</option>
+                        <option value="draw">Draw</option>
                     </select>
                     <button type="submit">Submit</button>
                 </form>


### PR DESCRIPTION
## Summary
- allow matches to end in a draw
- update Elo calculation for draws
- track win percentage on leaderboard with optional last-n filter
- include draw option in all result forms

## Testing
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_68587bae11c0832aa60175f251360ac6