### PR TITLE
Implement bulk add and profile pictures

### DIFF
--- a/models.py
+++ b/models.py
@@ -10,6 +10,7 @@ class Amiibo(db.Model):
     league = db.Column(db.String(20), default="")
     ko_titles = db.Column(db.String(120), default="")
     waiting = db.Column(db.Boolean, default=False)
+    profile_pic = db.Column(db.String(120), default="")
 
     @property
     def title(self) -> str:

--- a/static/style.css
+++ b/static/style.css
@@ -98,3 +98,28 @@ body.dark-mode {
     --header-bg: #222;
     --border-color: #444;
 }
+
+.podium {
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    gap: 1em;
+    margin-bottom: 1em;
+}
+
+.podium .position img {
+    border: 2px solid var(--accent-color);
+}
+
+.podium .first img { height: 120px; }
+.podium .second img { height: 100px; }
+.podium .third img { height: 100px; }
+
+.thumb {
+    height: 40px;
+}
+
+.bracket, .standings {
+    max-width: 600px;
+    margin: 0 auto 1em auto;
+}

--- a/templates/knockout.html
+++ b/templates/knockout.html
@@ -4,7 +4,7 @@
 {% for key, data in brackets.items() %}
   <h2>Bracket {{ key }}</h2>
   {% if data.pairs %}
-  <table>
+  <table class="bracket">
     <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
     {% for m in data.pairs %}
     <tr>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -1,15 +1,30 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Leaderboard</h1>
+{% if podium %}
+<div class="podium">
+  {% for a in podium %}
+  {% set cls = 'first' if loop.index0 == 0 else 'second' if loop.index0 == 1 else 'third' %}
+  <div class="position {{ cls }}">
+    {% if a.profile_pic %}
+      <img src="/profile/{{ a.profile_pic }}" alt="{{ a.name }}" />
+    {% endif %}
+    <div class="name">{{ a.name }}</div>
+    <div class="elo">{{ a.current_elo }}</div>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
 <form method="get" action="/leaderboard">
     <label>Win% over last</label>
     <input type="number" name="last" min="1" value="{{ last or '' }}">
     <button type="submit">Apply</button>
 </form>
 <table class="leaderboard">
-    <tr><th>Name</th><th>Title</th><th>Current Elo</th><th>Peak Elo</th><th>League</th><th>KO Titles</th><th>Win %</th></tr>
+    <tr><th>Pic</th><th>Name</th><th>Title</th><th>Current Elo</th><th>Peak Elo</th><th>League</th><th>KO Titles</th><th>Win %</th><th>Upload</th></tr>
     {% for amiibo in amiibos %}
     <tr>
+        <td>{% if amiibo.profile_pic %}<img src="/profile/{{ amiibo.profile_pic }}" class="thumb" alt="{{ amiibo.name }}">{% endif %}</td>
         <td>{{ amiibo.name }}</td>
         <td>{{ amiibo.title }}</td>
         <td>{{ amiibo.current_elo }}</td>
@@ -17,6 +32,12 @@
         <td>{{ amiibo.league }}</td>
         <td>{{ amiibo.ko_titles }}</td>
         <td>{{ amiibo.win_percentage(last)|round(1) }}</td>
+        <td>
+          <form method="post" action="/upload_pic/{{ amiibo.id }}" enctype="multipart/form-data">
+            <input type="file" name="picture" accept="image/*">
+            <button type="submit">Save</button>
+          </form>
+        </td>
     </tr>
     {% endfor %}
 </table>
@@ -24,5 +45,10 @@
     <h3>Add Amiibo</h3>
     <input type="text" name="name" placeholder="Name" required>
     <button type="submit">Add</button>
+</form>
+<form method="post" action="/add_amiibos">
+    <h3>Bulk Add Amiibos</h3>
+    <textarea name="names" rows="4" cols="30" placeholder="One name per line"></textarea>
+    <button type="submit">Add Many</button>
 </form>
 {% endblock %}

--- a/templates/league.html
+++ b/templates/league.html
@@ -3,13 +3,13 @@
 <h1>Leagues</h1>
 {% for lg, players, matches in leagues %}
 <h2>League {{ lg }}</h2>
-<table>
+<table class="standings">
   <tr><th>Name</th><th>Wins</th></tr>
   {% for p, sc in players %}
   <tr><td>{{ p.name }}</td><td>{{ sc }}</td></tr>
   {% endfor %}
 </table>
-<table>
+<table class="bracket">
   <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
 {% for m in matches %}
   <tr>

--- a/templates/swiss.html
+++ b/templates/swiss.html
@@ -3,7 +3,7 @@
 <h1>Initial Swiss</h1>
 {% if scores %}
 <h2>Round {{ round_no }}</h2>
-<table>
+<table class="standings">
     <tr><th>Name</th><th>Score</th><th>League</th></tr>
     {% for p in players %}
     <tr>
@@ -14,7 +14,7 @@
     {% endfor %}
 </table>
 {% if pairs %}
-<table>
+<table class="bracket">
     <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
     {% for match in pairs %}
     <tr>

--- a/templates/tournament.html
+++ b/templates/tournament.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h1>Tournament</h1>
 {% if pairs %}
-<table>
+<table class="bracket">
     <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
     {% for match in pairs %}
     <tr>


### PR DESCRIPTION
## Summary
- enable profile pictures for Amiibos and show top three on a podium
- allow bulk adding Amiibos
- add upload form for each Amiibo image
- apply minor style improvements to tables and leaderboard

## Testing
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_685cd3052240832aa8eebcd56b4d0727