### PR TITLE
Improve podium UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -87,7 +87,8 @@ def leaderboard():
     amiibos = Amiibo.query.order_by(Amiibo.current_elo.desc()).all()
     podium = amiibos[:3]
     others = amiibos[3:]
-    return render_template('leaderboard.html', amiibos=others, podium=podium, last=last)
+    offset = len(podium)
+    return render_template('leaderboard.html', amiibos=others, podium=podium, last=last, offset=offset)
 
 @app.route('/add_amiibo', methods=['POST'])
 def add_amiibo():

--- a/static/style.css
+++ b/static/style.css
@@ -107,13 +107,52 @@ body.dark-mode {
     margin-bottom: 1em;
 }
 
-.podium .position img {
-    border: 2px solid var(--accent-color);
+.podium .position {
+    position: relative;
+    text-align: center;
 }
 
-.podium .first img { height: 120px; }
-.podium .second img { height: 100px; }
-.podium .third img { height: 100px; }
+.podium .position img,
+.podium .position .placeholder {
+    border: 2px solid var(--accent-color);
+    display: block;
+    margin: 0 auto;
+}
+
+.podium .position .placeholder {
+    background: #333;
+    color: #777;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.podium .first img, .podium .first .placeholder { height: 120px; width: 120px; }
+.podium .second img, .podium .second .placeholder { height: 100px; width: 100px; }
+.podium .third img, .podium .third .placeholder { height: 100px; width: 100px; }
+
+.podium .place {
+    position: absolute;
+    top: -12px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--accent-color);
+    color: #fff;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    font-size: 0.9em;
+}
+
+.pic-upload input[type="file"] {
+    width: 100%;
+    margin: 0.2em 0;
+}
+
 
 .thumb {
     height: 40px;

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -6,8 +6,15 @@
   {% for a in podium %}
   {% set cls = 'first' if loop.index0 == 0 else 'second' if loop.index0 == 1 else 'third' %}
   <div class="position {{ cls }}">
+    <div class="place">{{ loop.index }}</div>
     {% if a.profile_pic %}
       <img src="/profile/{{ a.profile_pic }}" alt="{{ a.name }}" />
+    {% else %}
+      <div class="placeholder"></div>
+      <form method="post" action="/upload_pic/{{ a.id }}" enctype="multipart/form-data" class="pic-upload">
+        <input type="file" name="picture" accept="image/*">
+        <button type="submit">Save</button>
+      </form>
     {% endif %}
     <div class="name">{{ a.name }}</div>
     <div class="elo">{{ a.current_elo }}</div>
@@ -21,9 +28,10 @@
     <button type="submit">Apply</button>
 </form>
 <table class="leaderboard">
-    <tr><th>Pic</th><th>Name</th><th>Title</th><th>Current Elo</th><th>Peak Elo</th><th>League</th><th>KO Titles</th><th>Win %</th><th>Upload</th></tr>
+    <tr><th>#</th><th>Pic</th><th>Name</th><th>Title</th><th>Current Elo</th><th>Peak Elo</th><th>League</th><th>KO Titles</th><th>Win %</th><th>Upload</th></tr>
     {% for amiibo in amiibos %}
     <tr>
+        <td>{{ loop.index + offset }}</td>
         <td>{% if amiibo.profile_pic %}<img src="/profile/{{ amiibo.profile_pic }}" class="thumb" alt="{{ amiibo.name }}">{% endif %}</td>
         <td>{{ amiibo.name }}</td>
         <td>{{ amiibo.title }}</td>


### PR DESCRIPTION
## Summary
- show ranking numbers and upload form on podium
- display ranking number column on the leaderboard
- provide placeholder styling and update CSS

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cd6cd2f7c832a990ffb448ca1ceed