### PR TITLE
Add Amiibo profile pages

### DIFF
--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -16,7 +16,7 @@
         <button type="submit">Save</button>
       </form>
     {% endif %}
-    <div class="name">{{ a.name }}</div>
+    <div class="name"><a href="/amiibo/{{ a.id }}">{{ a.name }}</a></div>
     <div class="elo">{{ a.current_elo }}</div>
   </div>
   {% endfor %}
@@ -33,7 +33,7 @@
     <tr>
         <td>{{ loop.index + offset }}</td>
         <td>{% if amiibo.profile_pic %}<img src="/profile/{{ amiibo.profile_pic }}" class="thumb" alt="{{ amiibo.name }}">{% endif %}</td>
-        <td>{{ amiibo.name }}</td>
+        <td><a href="/amiibo/{{ amiibo.id }}">{{ amiibo.name }}</a></td>
         <td>{{ amiibo.title }}</td>
         <td>{{ amiibo.current_elo }}</td>
         <td>{{ amiibo.peak_elo }}</td>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ amiibo.name }}</h1>
+<div>
+  {% if amiibo.profile_pic %}
+    <img src="/profile/{{ amiibo.profile_pic }}" class="thumb" alt="{{ amiibo.name }}">
+  {% endif %}
+  <p>Current Elo: {{ amiibo.current_elo }}</p>
+</div>
+<canvas id="ratingChart" width="400" height="200"></canvas>
+<h2>Match History</h2>
+<table class="bracket">
+  <tr><th>ID</th><th>Opponent</th><th>Result</th></tr>
+  {% for m in matches %}
+  <tr>
+    <td>{{ m.id }}</td>
+    <td>{{ m.opponent }}</td>
+    <td>{{ m.result }}</td>
+  </tr>
+  {% endfor %}
+</table>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+var ctx = document.getElementById('ratingChart').getContext('2d');
+var chart = new Chart(ctx, {
+    type: 'line',
+    data: {
+        labels: {{ rating_labels|safe }},
+        datasets: [{
+            label: 'Elo',
+            data: {{ rating_values|safe }},
+            borderColor: 'rgba(217,35,35,1)',
+            backgroundColor: 'rgba(217,35,35,0.2)',
+            fill: false,
+        }]
+    },
+    options: {
+        scales: { y: { beginAtZero: false } }
+    }
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/amiibo/<id>` route to show individual Amiibo profile
- show rating history and match list on the profile page
- link Amiibo names on leaderboard to their profile pages

## Testing
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_685d1b56c1d4832aa64cccda8b7572a7