### PR TITLE
Improve profile layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -131,12 +131,17 @@ def amiibo_profile(amiibo_id):
             result = 'Win' if m.winner_id == amiibo_id else 'Loss'
         display.append({'id': m.id, 'opponent': opponent.name, 'result': result})
 
+    show_all = request.args.get('all') == '1'
+    if not show_all:
+        display = display[:5]
+
     return render_template(
         'profile.html',
         amiibo=amiibo,
         rating_labels=history_labels,
         rating_values=history_values,
         matches=display,
+        show_all=show_all,
     )
 
 @app.route('/add_amiibo', methods=['POST'])

--- a/static/style.css
+++ b/static/style.css
@@ -162,3 +162,23 @@ body.dark-mode {
     max-width: 600px;
     margin: 0 auto 1em auto;
 }
+
+.profile-layout {
+    display: flex;
+    gap: 1em;
+    align-items: flex-start;
+}
+
+.chart-container {
+    background: #333;
+    padding: 0.5em;
+    border-radius: 4px;
+}
+
+.chart-container .graph {
+    background: #222;
+}
+
+.history-container {
+    flex: 1;
+}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -7,18 +7,29 @@
   {% endif %}
   <p>Current Elo: {{ amiibo.current_elo }}</p>
 </div>
-<canvas id="ratingChart" width="400" height="200"></canvas>
-<h2>Match History</h2>
-<table class="bracket">
-  <tr><th>ID</th><th>Opponent</th><th>Result</th></tr>
-  {% for m in matches %}
-  <tr>
-    <td>{{ m.id }}</td>
-    <td>{{ m.opponent }}</td>
-    <td>{{ m.result }}</td>
-  </tr>
-  {% endfor %}
-</table>
+<div class="profile-layout">
+  <div class="chart-container">
+    <canvas id="ratingChart" width="300" height="150" class="graph"></canvas>
+  </div>
+  <div class="history-container">
+    <h2>Match History</h2>
+    <table class="bracket">
+      <tr><th>ID</th><th>Opponent</th><th>Result</th></tr>
+      {% for m in matches %}
+      <tr>
+        <td>{{ m.id }}</td>
+        <td>{{ m.opponent }}</td>
+        <td>{{ m.result }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+    {% if not show_all %}
+      <a href="?all=1">Show all matches</a>
+    {% else %}
+      <a href="?">Show less</a>
+    {% endif %}
+  </div>
+</div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
 var ctx = document.getElementById('ratingChart').getContext('2d');


### PR DESCRIPTION
## Summary
- shrink rating chart and set dark background
- display match history next to the chart
- default to last five matches and add link for all matches

## Testing
- `pytest` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_685d210a2780832ab76f561198fcdc6c