### PR TITLE
Improve profile layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -182,3 +182,20 @@ body.dark-mode {
 .history-container {
     flex: 1;
 }
+
+.profile-main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+}
+
+.picture-container {
+    text-align: center;
+}
+
+.profile-pic {
+    width: 200px;
+    height: auto;
+    border: 2px solid var(--accent-color);
+}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,19 +1,15 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>{{ amiibo.name }}</h1>
-<div>
-  {% if amiibo.profile_pic %}
-    <img src="/profile/{{ amiibo.profile_pic }}" class="thumb" alt="{{ amiibo.name }}">
-  {% endif %}
-  <p>Current Elo: {{ amiibo.current_elo }}</p>
-</div>
 <div class="profile-layout">
-  <div class="chart-container">
-    <canvas id="ratingChart" width="300" height="150" class="graph"></canvas>
-  </div>
-  <div class="history-container">
-    <h2>Match History</h2>
-    <table class="bracket">
+  <div class="profile-main">
+    <p>Current Elo: {{ amiibo.current_elo }}</p>
+    <div class="chart-container">
+      <canvas id="ratingChart" width="300" height="150" class="graph"></canvas>
+    </div>
+    <div class="history-container">
+      <h2>Match History</h2>
+      <table class="bracket">
       <tr><th>ID</th><th>Opponent</th><th>Result</th></tr>
       {% for m in matches %}
       <tr>
@@ -27,6 +23,12 @@
       <a href="?all=1">Show all matches</a>
     {% else %}
       <a href="?">Show less</a>
+      {% endif %}
+    </div>
+  </div>
+  <div class="picture-container">
+    {% if amiibo.profile_pic %}
+      <img src="/profile/{{ amiibo.profile_pic }}" class="profile-pic" alt="{{ amiibo.name }}">
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
## Summary
- show Elo, graph, and match history in a left column
- show larger profile picture on the right
- add CSS helpers for new layout

## Testing
- `python -m py_compile app.py models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d220d0b20832aaba2a3731eb6ecdf