### PR TITLE
Improve KO bracket generation

### DIFF
--- a/templates/knockout.html
+++ b/templates/knockout.html
@@ -3,43 +3,43 @@
 <h1>Knockout Brackets</h1>
 {% for key, data in brackets.items() %}
   <h2>Bracket {{ key }}</h2>
-  {% if data.pairs %}
-  <table class="bracket">
-    <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
-    {% for m in data.pairs %}
-    <tr>
-      <td>{{ m[0].name }}</td>
-      <td>{{ m[1].name }}</td>
-      <td>
-        {% if m[2] %}
-          {% if m[2] == 'Draw' %}
-            Draw
+  {% for pairs in data.rounds %}
+    <h3>Round {{ loop.index }}</h3>
+    {% if pairs %}
+    <table class="bracket">
+      <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
+      {% for m in pairs %}
+      <tr>
+        <td>{{ m[0].name }}</td>
+        <td>{{ m[1].name }}</td>
+        <td>
+          {% if m[2] %}
+            {% if m[2] == 'Draw' %}
+              Draw
+            {% else %}
+              {{ m[2].name }}
+            {% endif %}
           {% else %}
-            {{ m[2].name }}
+            <form method="post" action="/report_knockout_result">
+              <input type="hidden" name="bracket" value="{{ key }}">
+              <input type="hidden" name="player1" value="{{ m[0].id }}">
+              <input type="hidden" name="player2" value="{{ m[1].id }}">
+              <select name="winner" required>
+                <option value="{{ m[0].id }}">{{ m[0].name }}</option>
+                <option value="{{ m[1].id }}">{{ m[1].name }}</option>
+                <option value="draw">Draw</option>
+              </select>
+              <button type="submit">Submit</button>
+            </form>
           {% endif %}
-        {% else %}
-          <form method="post" action="/report_knockout_result">
-            <input type="hidden" name="bracket" value="{{ key }}">
-            <input type="hidden" name="player1" value="{{ m[0].id }}">
-            <input type="hidden" name="player2" value="{{ m[1].id }}">
-            <select name="winner" required>
-              <option value="{{ m[0].id }}">{{ m[0].name }}</option>
-              <option value="{{ m[1].id }}">{{ m[1].name }}</option>
-              <option value="draw">Draw</option>
-            </select>
-            <button type="submit">Submit</button>
-          </form>
-        {% endif %}
-      </td>
-    </tr>
-    {% endfor %}
-  </table>
-  {% else %}
-    {% if data.winner %}
-      <p>Winner: {{ data.winner.name }}</p>
-    {% else %}
-      <p>No matches.</p>
+        </td>
+      </tr>
+      {% endfor %}
+    </table>
     {% endif %}
+  {% endfor %}
+  {% if data.winner %}
+    <p>Winner: {{ data.winner.name }}</p>
   {% endif %}
 {% endfor %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- support leftover leagues by creating KO brackets from single leagues
- keep KO bracket history for full bracket display
- render knockout.html by round to show all bracket stages

## Testing
- `python -m py_compile app.py models.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d251e0aa4832a926e135b6cf33a74