### PR TITLE
Persist state in database

### DIFF
--- a/models.py
+++ b/models.py
@@ -67,3 +67,11 @@ class Match(db.Model):
     winner_id = db.Column(db.Integer, db.ForeignKey('amiibo.id'), nullable=True)
     draw = db.Column(db.Boolean, default=False)
     round_no = db.Column(db.Integer, default=1)
+
+
+class State(db.Model):
+    """Generic key/value store for persisting application state."""
+
+    key = db.Column(db.String(50), primary_key=True)
+    value = db.Column(db.Text)
+


### PR DESCRIPTION
## Summary
- remove duplicate in-memory state initialization which reset data on start

## Testing
- `python -m py_compile app.py models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d58a69600832a8ffc76d5bdd457d3