### PR TITLE
Add score-based results with tiebreakers

### DIFF
--- a/models.py
+++ b/models.py
@@ -67,6 +67,8 @@ class Match(db.Model):
     winner_id = db.Column(db.Integer, db.ForeignKey('amiibo.id'), nullable=True)
     draw = db.Column(db.Boolean, default=False)
     round_no = db.Column(db.Integer, default=1)
+    score1 = db.Column(db.Integer, default=0)
+    score2 = db.Column(db.Integer, default=0)
 
 
 class State(db.Model):

--- a/templates/knockout.html
+++ b/templates/knockout.html
@@ -24,11 +24,8 @@
               <input type="hidden" name="bracket" value="{{ key }}">
               <input type="hidden" name="player1" value="{{ m[0].id }}">
               <input type="hidden" name="player2" value="{{ m[1].id }}">
-              <select name="winner" required>
-                <option value="{{ m[0].id }}">{{ m[0].name }}</option>
-                <option value="{{ m[1].id }}">{{ m[1].name }}</option>
-                <option value="draw">Draw</option>
-              </select>
+              <input type="number" name="score1" min="0" required>
+              <input type="number" name="score2" min="0" required>
               <button type="submit">Submit</button>
             </form>
           {% endif %}

--- a/templates/league.html
+++ b/templates/league.html
@@ -4,9 +4,15 @@
 {% for lg, players, matches in leagues %}
 <h2>League {{ lg }}</h2>
 <table class="standings">
-  <tr><th>Name</th><th>Wins</th></tr>
-  {% for p, sc in players %}
-  <tr><td>{{ p.name }}</td><td>{{ sc }}</td></tr>
+  <tr><th>Name</th><th>Score</th><th>Diff</th><th>Wins</th><th>SB</th></tr>
+  {% for p, sc, diff, wins, sb in players %}
+  <tr>
+    <td>{{ p.name }}</td>
+    <td>{{ sc }}</td>
+    <td>{{ diff }}</td>
+    <td>{{ wins }}</td>
+    <td>{{ sb }}</td>
+  </tr>
   {% endfor %}
 </table>
 <table class="bracket">
@@ -27,11 +33,8 @@
             <input type="hidden" name="league" value="{{ lg }}">
             <input type="hidden" name="player1" value="{{ m[0].id }}">
             <input type="hidden" name="player2" value="{{ m[1].id }}">
-            <select name="winner" required>
-                <option value="{{ m[0].id }}">{{ m[0].name }}</option>
-                <option value="{{ m[1].id }}">{{ m[1].name }}</option>
-                <option value="draw">Draw</option>
-            </select>
+            <input type="number" name="score1" min="0" required>
+            <input type="number" name="score2" min="0" required>
             <button type="submit">Submit</button>
         </form>
       {% endif %}

--- a/templates/swiss.html
+++ b/templates/swiss.html
@@ -4,11 +4,14 @@
 {% if scores %}
 <h2>Round {{ round_no }}</h2>
 <table class="standings">
-    <tr><th>Name</th><th>Score</th><th>League</th></tr>
+    <tr><th>Name</th><th>Score</th><th>Diff</th><th>Wins</th><th>Buchholz</th><th>League</th></tr>
     {% for p in players %}
     <tr>
         <td>{{ p.name }}</td>
         <td>{{ scores[p.id] }}</td>
+        <td>{{ diff[p.id] }}</td>
+        <td>{{ wins[p.id] }}</td>
+        <td>{{ buchholz[p.id] }}</td>
         <td>{{ p.league }}</td>
     </tr>
     {% endfor %}
@@ -31,11 +34,8 @@
                 <form method="post" action="/report_swiss_result">
                     <input type="hidden" name="player1" value="{{ match[0].id }}">
                     <input type="hidden" name="player2" value="{{ match[1].id }}">
-                    <select name="winner" required>
-                        <option value="{{ match[0].id }}">{{ match[0].name }}</option>
-                        <option value="{{ match[1].id }}">{{ match[1].name }}</option>
-                        <option value="draw">Draw</option>
-                    </select>
+                    <input type="number" name="score1" min="0" required>
+                    <input type="number" name="score2" min="0" required>
                     <button type="submit">Submit</button>
                 </form>
             {% endif %}

--- a/templates/tournament.html
+++ b/templates/tournament.html
@@ -19,11 +19,8 @@
                 <form method="post" action="/report_result">
                     <input type="hidden" name="player1" value="{{ match[0].id }}">
                     <input type="hidden" name="player2" value="{{ match[1].id }}">
-                    <select name="winner" required>
-                        <option value="{{ match[0].id }}">{{ match[0].name }}</option>
-                        <option value="{{ match[1].id }}">{{ match[1].name }}</option>
-                        <option value="draw">Draw</option>
-                    </select>
+                    <input type="number" name="score1" min="0" required>
+                    <input type="number" name="score2" min="0" required>
                     <button type="submit">Submit</button>
                 </form>
             {% endif %}


### PR DESCRIPTION
## Summary
- support entering numeric results for all matches
- store match scores in the database
- keep Swiss/League point differentials and win counts
- compute Buchholz and Sonneborn–Berger tiebreakers
- update league promotion logic and templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ebbcb0fd0832a9e3eeab1aa0e9b21