### PR TITLE
Add season history page

### DIFF
--- a/models.py
+++ b/models.py
@@ -77,3 +77,11 @@ class State(db.Model):
     key = db.Column(db.String(50), primary_key=True)
     value = db.Column(db.Text)
 
+
+class Season(db.Model):
+    """Archive data for a completed season."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    league_data = db.Column(db.Text)
+    knockout_data = db.Column(db.Text)
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,7 @@
         <a href="/swiss">Swiss</a>
         <a href="/league">League</a>
         <a href="/knockout">Knockout</a>
+        <a href="/seasons">Seasons</a>
         <button id="theme-toggle" class="theme-toggle">Dark Mode</button>
     </nav>
     <main class="content">

--- a/templates/seasons.html
+++ b/templates/seasons.html
@@ -1,0 +1,68 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Past Seasons</h1>
+{% for season in seasons %}
+  <h2>Season {{ season.id }}</h2>
+  {% for lg, players, matches in season.leagues %}
+    <h3>League {{ lg }}</h3>
+    <table class="standings">
+      <tr><th>Name</th><th>Score</th><th>Diff</th><th>Wins</th><th>SB</th></tr>
+      {% for p, sc, diff, wins, sb in players %}
+      <tr>
+        <td>{{ p.name }}</td>
+        <td>{{ sc }}</td>
+        <td>{{ diff }}</td>
+        <td>{{ wins }}</td>
+        <td>{{ sb }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+    <table class="bracket">
+      <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
+      {% for m in matches %}
+      <tr>
+        <td>{{ m[0].name }}</td>
+        <td>{{ m[1].name }}</td>
+        <td>
+          {% if m[2] %}
+            {% if m[2] == 'Draw' %}
+              Draw
+            {% else %}
+              {{ m[2].name }}
+            {% endif %}
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </table>
+  {% endfor %}
+  {% for key, data in season.brackets.items() %}
+    <h3>Bracket {{ key }}</h3>
+    {% for pairs in data.rounds %}
+      <h4>Round {{ loop.index }}</h4>
+      <table class="bracket">
+        <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
+        {% for m in pairs %}
+        <tr>
+          <td>{{ m[0].name }}</td>
+          <td>{{ m[1].name }}</td>
+          <td>
+            {% if m[2] %}
+              {% if m[2] == 'Draw' %}
+                Draw
+              {% else %}
+                {{ m[2].name }}
+              {% endif %}
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </table>
+    {% endfor %}
+    {% if data.winner %}
+      <p>Winner: {{ data.winner.name }}</p>
+    {% endif %}
+  {% endfor %}
+{% endfor %}
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- store completed season data in a new `Season` table
- archive league tables and knockout brackets when a season finishes
- provide `/seasons` page to view prior seasons
- link the new page from the navbar

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861060e0e88832aae65eb9a40167ba0