### PR TITLE
Show only winners on past seasons page

### DIFF
--- a/app.py
+++ b/app.py
@@ -840,34 +840,14 @@ def seasons_view():
                 for pid in sc
             ]
             players.sort(key=lambda x: (x[1], x[2], x[3], x[4]), reverse=True)
-            def resolve(w):
-                if w == 'draw':
-                    return 'Draw'
-                return Amiibo.query.get(w) if w else None
-            matches = [
-                (Amiibo.query.get(p1), Amiibo.query.get(p2), resolve(w))
-                for p1, p2, w in league.get('matches', {}).get(lg, [])
-            ]
-            leagues_disp.append((lg, players, matches))
+            winner = players[0][0] if players else None
+            leagues_disp.append((lg, winner))
 
         brackets = {}
-        history = knockout.get('history', {})
         winners = knockout.get('winners', {})
-        def resolve(w):
-            if w == 'draw':
-                return 'Draw'
-            return Amiibo.query.get(w) if w else None
-        for key, rounds in history.items():
-            rounds_disp = []
-            for pairs in rounds:
-                rounds_disp.append([
-                    (Amiibo.query.get(p1), Amiibo.query.get(p2), resolve(w))
-                    for p1, p2, w in pairs
-                ])
-            win = None
-            if key in winners and winners[key]:
-                win = Amiibo.query.get(winners[key][0])
-            brackets[key] = {'rounds': rounds_disp, 'winner': win}
+        for key, w in winners.items():
+            win = Amiibo.query.get(w[0]) if w else None
+            brackets[key] = win
 
         items.append({'id': s.id, 'leagues': leagues_disp, 'brackets': brackets})
 

--- a/templates/seasons.html
+++ b/templates/seasons.html
@@ -1,68 +1,18 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Past Seasons</h1>
-{% for season in seasons %}
-  <h2>Season {{ season.id }}</h2>
-  {% for lg, players, matches in season.leagues %}
-    <h3>League {{ lg }}</h3>
-    <table class="standings">
-      <tr><th>Name</th><th>Score</th><th>Diff</th><th>Wins</th><th>SB</th></tr>
-      {% for p, sc, diff, wins, sb in players %}
-      <tr>
-        <td>{{ p.name }}</td>
-        <td>{{ sc }}</td>
-        <td>{{ diff }}</td>
-        <td>{{ wins }}</td>
-        <td>{{ sb }}</td>
-      </tr>
-      {% endfor %}
-    </table>
-    <table class="bracket">
-      <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
-      {% for m in matches %}
-      <tr>
-        <td>{{ m[0].name }}</td>
-        <td>{{ m[1].name }}</td>
-        <td>
-          {% if m[2] %}
-            {% if m[2] == 'Draw' %}
-              Draw
-            {% else %}
-              {{ m[2].name }}
-            {% endif %}
-          {% endif %}
-        </td>
-      </tr>
-      {% endfor %}
-    </table>
-  {% endfor %}
-  {% for key, data in season.brackets.items() %}
-    <h3>Bracket {{ key }}</h3>
-    {% for pairs in data.rounds %}
-      <h4>Round {{ loop.index }}</h4>
-      <table class="bracket">
-        <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
-        {% for m in pairs %}
-        <tr>
-          <td>{{ m[0].name }}</td>
-          <td>{{ m[1].name }}</td>
-          <td>
-            {% if m[2] %}
-              {% if m[2] == 'Draw' %}
-                Draw
-              {% else %}
-                {{ m[2].name }}
-              {% endif %}
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-      </table>
+  {% for season in seasons %}
+    <h2>Season {{ season.id }}</h2>
+    {% for lg, winner in season.leagues %}
+      {% if winner %}
+        <p>League {{ lg }} winner: {{ winner.name }}</p>
+      {% endif %}
     {% endfor %}
-    {% if data.winner %}
-      <p>Winner: {{ data.winner.name }}</p>
-    {% endif %}
+    {% for key, winner in season.brackets.items() %}
+      {% if winner %}
+        <p>K.O. {{ key }} winner: {{ winner.name }}</p>
+      {% endif %}
+    {% endfor %}
   {% endfor %}
-{% endfor %}
-{% endblock %}
+  {% endblock %}
 


### PR DESCRIPTION
## Summary
- Simplify past seasons view to display only league and knockout winners

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689523af4cd4832abb6a5ff277bf2e3e