### PR TITLE
Preserve scroll position after submitting results

### DIFF
--- a/static/scroll.js
+++ b/static/scroll.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const pos = localStorage.getItem('scrollpos');
+    if (pos) {
+        window.scrollTo(0, parseInt(pos, 10));
+        localStorage.removeItem('scrollpos');
+    }
+});
+
+window.addEventListener('beforeunload', function() {
+    localStorage.setItem('scrollpos', window.scrollY);
+});
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,5 +21,6 @@
         {% block content %}{% endblock %}
     </main>
     <script src="/static/darkmode.js"></script>
+    <script src="/static/scroll.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Restore previous scroll offset after page reloads and form submissions
- Add client-side script to save and load scroll position

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689529b918f4832aa3345a4834951ca6