### PR TITLE
Track league titles on leaderboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -614,6 +614,13 @@ def promote_and_relegate():
         )
         if ordered:
             rankings[g] = list(ordered)
+    # Award league titles to the top player in each group
+    for g, rank in rankings.items():
+        if rank:
+            champ = Amiibo.query.get(rank[0])
+            champ.league_titles = (
+                (champ.league_titles + ',' if champ.league_titles else '') + g
+            )
     promotions = {}
     relegations = {}
     for i, g in enumerate(groups):

--- a/models.py
+++ b/models.py
@@ -9,6 +9,7 @@ class Amiibo(db.Model):
     peak_elo = db.Column(db.Integer, default=1500)
     league = db.Column(db.String(20), default="")
     ko_titles = db.Column(db.String(120), default="")
+    league_titles = db.Column(db.String(120), default="")
     waiting = db.Column(db.Boolean, default=False)
     profile_pic = db.Column(db.String(120), default="")
 

--- a/static/style.css
+++ b/static/style.css
@@ -72,6 +72,13 @@ table, th, td {
     text-align: left;
 }
 
+.leaderboard th.titles,
+.leaderboard td.titles {
+    white-space: nowrap;
+    max-width: 80px;
+    overflow-x: auto;
+}
+
 button {
     background: var(--accent-color);
     color: #fff;

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -28,7 +28,7 @@
     <button type="submit">Apply</button>
 </form>
 <table class="leaderboard">
-    <tr><th>#</th><th>Pic</th><th>Name</th><th>Title</th><th>Current Elo</th><th>Peak Elo</th><th>League</th><th>KO Titles</th><th>Win %</th><th>Upload</th></tr>
+    <tr><th>#</th><th>Pic</th><th>Name</th><th>Title</th><th>Current Elo</th><th>Peak Elo</th><th>League</th><th class="titles">KO Titles</th><th class="titles">League Titles</th><th>Win %</th><th>Upload</th></tr>
     {% for amiibo in amiibos %}
     <tr>
         <td>{{ loop.index }}</td>
@@ -38,7 +38,8 @@
         <td>{{ amiibo.current_elo }}</td>
         <td>{{ amiibo.peak_elo }}</td>
         <td>{{ amiibo.league }}</td>
-        <td>{{ amiibo.ko_titles }}</td>
+        <td class="titles">{{ amiibo.ko_titles }}</td>
+        <td class="titles">{{ amiibo.league_titles }}</td>
         <td>{{ amiibo.win_percentage(last)|round(1) }}</td>
         <td>
           <form method="post" action="/upload_pic/{{ amiibo.id }}" enctype="multipart/form-data">


### PR DESCRIPTION
## Summary
- Store league titles for each Amiibo
- Award league winners at end of season and display on leaderboard
- Keep title columns stable with nowrap/scroll styling

## Testing
- `python -m py_compile app.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_68952c4eab8c832ab10b6a5a6cbb83bb