### PR TITLE
Organize league matches into rounds with tabs

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -211,3 +211,29 @@ body.dark-mode {
     height: auto;
     border: 2px solid var(--accent-color);
 }
+
+.hidden {
+    display: none;
+}
+
+.round-tabs {
+    margin-bottom: 1em;
+}
+
+.tab-links {
+    margin-bottom: 0.5em;
+}
+
+.tab-link {
+    background: var(--header-bg);
+    color: var(--link-color);
+    border: 1px solid var(--border-color);
+    margin-right: 0.5em;
+    padding: 0.25em 0.5em;
+    cursor: pointer;
+}
+
+.tab-link.active {
+    background: var(--accent-color);
+    color: #fff;
+}

--- a/templates/league.html
+++ b/templates/league.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Leagues</h1>
-{% for lg, players, matches in leagues %}
+{% for lg, players, rounds in leagues %}
 <h2>League {{ lg }}</h2>
 <table class="standings">
   <tr><th>Name</th><th>Score</th><th>Diff</th><th>Wins</th><th>SB</th></tr>
@@ -15,35 +15,62 @@
   </tr>
   {% endfor %}
 </table>
-<table class="bracket">
-  <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
-{% for m in matches %}
-  <tr>
-    <td>{{ m[0].name }}</td>
-    <td>{{ m[1].name }}</td>
-    <td>
-      {% if m[2] %}
-        {% if m[2] == 'Draw' %}
-          Draw
-        {% else %}
-          {{ m[2].name }}
-        {% endif %}
-      {% else %}
-        <form method="post" action="/report_league_result">
-            <input type="hidden" name="league" value="{{ lg }}">
-            <input type="hidden" name="player1" value="{{ m[0].id }}">
-            <input type="hidden" name="player2" value="{{ m[1].id }}">
-            <input type="number" name="score1" min="0" required>
-            <input type="number" name="score2" min="0" required>
-            <button type="submit">Submit</button>
-        </form>
-      {% endif %}
-    </td>
-  </tr>
-{% endfor %}
-</table>
+<div class="round-tabs">
+  <div class="tab-links">
+    {% for rnd, _ in rounds %}
+      <button type="button"
+              class="tab-link{% if loop.first %} active{% endif %}"
+              data-target="lg{{ lg }}-round{{ rnd }}">Round {{ rnd }}</button>
+    {% endfor %}
+  </div>
+  {% for rnd, matches in rounds %}
+  <div id="lg{{ lg }}-round{{ rnd }}" class="tab-content{% if not loop.first %} hidden{% endif %}">
+    <table class="bracket">
+      <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
+      {% for m in matches %}
+      <tr>
+        <td>{{ m[0].name }}</td>
+        <td>{{ m[1].name }}</td>
+        <td>
+          {% if m[2] %}
+            {% if m[2] == 'Draw' %}
+              Draw
+            {% else %}
+              {{ m[2].name }}
+            {% endif %}
+          {% else %}
+            <form method="post" action="/report_league_result">
+                <input type="hidden" name="league" value="{{ lg }}">
+                <input type="hidden" name="player1" value="{{ m[0].id }}">
+                <input type="hidden" name="player2" value="{{ m[1].id }}">
+                <input type="hidden" name="round" value="{{ rnd }}">
+                <input type="number" name="score1" min="0" required>
+                <input type="number" name="score2" min="0" required>
+                <button type="submit">Submit</button>
+            </form>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </table>
+  </div>
+  {% endfor %}
+</div>
 {% endfor %}
 <form method="post" action="/finish_league">
     <button type="submit">Finish League</button>
 </form>
+<script>
+document.querySelectorAll('.round-tabs').forEach(function(tabs){
+  tabs.querySelectorAll('.tab-link').forEach(function(btn){
+    btn.addEventListener('click', function(){
+      const target = this.dataset.target;
+      tabs.querySelectorAll('.tab-content').forEach(function(tc){ tc.classList.add('hidden'); });
+      tabs.querySelectorAll('.tab-link').forEach(function(b){ b.classList.remove('active'); });
+      tabs.querySelector('#'+target).classList.remove('hidden');
+      this.classList.add('active');
+    });
+  });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Schedule league matches using a round-robin algorithm and store them by round.
- Allow reporting of match results per round and persist round info.
- Display league rounds in tabbed tables with supporting styles.

## Testing
- `python -m py_compile app.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_6895ba663fd0832a8abcf232adf7c77e