### PR TITLE
feat: add visual knockout bracket

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -175,6 +175,35 @@ body.dark-mode {
     margin: 0 auto 1em auto;
 }
 
+/* Knockout bracket layout */
+.ko-bracket {
+    display: flex;
+    gap: 2em;
+    overflow-x: auto;
+    margin-bottom: 1em;
+}
+
+.ko-bracket .round {
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+}
+
+.ko-bracket .match {
+    border: 1px solid var(--border-color);
+    padding: 0.5em;
+    background: #222;
+    min-width: 180px;
+}
+
+.ko-bracket .match .player {
+    font-weight: bold;
+}
+
+.ko-bracket .match .result {
+    margin-top: 0.5em;
+}
+
 .profile-layout {
     display: flex;
     gap: 1em;

--- a/templates/knockout.html
+++ b/templates/knockout.html
@@ -3,40 +3,40 @@
 <h1>Knockout Brackets</h1>
 {% for key, data in brackets.items() %}
   <h2>Bracket {{ key }}</h2>
-  {% for pairs in data.rounds %}
-    <h3>Round {{ loop.index }}</h3>
-    {% if pairs %}
-    <table class="bracket">
-      <tr><th>Player 1</th><th>Player 2</th><th>Winner</th></tr>
-      {% for m in pairs %}
-      <tr>
-        <td>{{ m[0].name }}</td>
-        <td>{{ m[1].name }}</td>
-        <td>
-          {% if m[2] %}
-            {% if m[2] == 'Draw' %}
-              Draw
+  <div class="ko-bracket">
+    {% for pairs in data.rounds %}
+      {% if pairs %}
+      <div class="round">
+        {% for m in pairs %}
+        <div class="match">
+          <div class="player">{{ m[0].name }}</div>
+          <div class="player">{{ m[1].name }}</div>
+          <div class="result">
+            {% if m[2] %}
+              {% if m[2] == 'Draw' %}
+                Draw
+              {% else %}
+                {{ m[2].name }}
+              {% endif %}
             {% else %}
-              {{ m[2].name }}
+              <form method="post" action="/report_knockout_result">
+                <input type="hidden" name="bracket" value="{{ key }}">
+                <input type="hidden" name="player1" value="{{ m[0].id }}">
+                <input type="hidden" name="player2" value="{{ m[1].id }}">
+                <input type="number" name="score1" min="0" required>
+                <input type="number" name="score2" min="0" required>
+                <button type="submit">Submit</button>
+              </form>
             {% endif %}
-          {% else %}
-            <form method="post" action="/report_knockout_result">
-              <input type="hidden" name="bracket" value="{{ key }}">
-              <input type="hidden" name="player1" value="{{ m[0].id }}">
-              <input type="hidden" name="player2" value="{{ m[1].id }}">
-              <input type="number" name="score1" min="0" required>
-              <input type="number" name="score2" min="0" required>
-              <button type="submit">Submit</button>
-            </form>
-          {% endif %}
-        </td>
-      </tr>
-      {% endfor %}
-    </table>
-    {% endif %}
-  {% endfor %}
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+    {% endfor %}
+  </div>
   {% if data.winner %}
-    <p>Winner: {{ data.winner.name }}</p>
+    <p class="champion">Winner: {{ data.winner.name }}</p>
   {% endif %}
 {% endfor %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- rework knockout template to render rounds as a flexbox bracket
- style knockout bracket with new CSS classes

## Testing
- `python -m py_compile app.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_6895c40b8550832a853ae2f8c17cfadf