### PR TITLE
Add connection lines and align knockout bracket

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -178,7 +178,8 @@ body.dark-mode {
 /* Knockout bracket layout */
 .ko-bracket {
     display: flex;
-    gap: 2em;
+    justify-content: center;
+    gap: 4em;
     overflow-x: auto;
     margin-bottom: 1em;
 }
@@ -186,7 +187,34 @@ body.dark-mode {
 .ko-bracket .round {
     display: flex;
     flex-direction: column;
-    gap: 1em;
+    justify-content: center;
+    gap: 2em;
+}
+
+.ko-bracket .pair {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 2em;
+    padding-right: 2em;
+}
+
+.ko-bracket .pair::before {
+    content: "";
+    position: absolute;
+    right: 1em;
+    top: 25%;
+    bottom: 25%;
+    border-right: 2px solid var(--border-color);
+}
+
+.ko-bracket .pair::after {
+    content: "";
+    position: absolute;
+    right: 0;
+    top: 50%;
+    width: 1em;
+    border-top: 2px solid var(--border-color);
 }
 
 .ko-bracket .match {
@@ -194,6 +222,16 @@ body.dark-mode {
     padding: 0.5em;
     background: #222;
     min-width: 180px;
+    position: relative;
+}
+
+.ko-bracket .pair .match::after {
+    content: "";
+    position: absolute;
+    right: -1em;
+    top: 50%;
+    width: 1em;
+    border-top: 2px solid var(--border-color);
 }
 
 .ko-bracket .match .player {

--- a/templates/knockout.html
+++ b/templates/knockout.html
@@ -4,31 +4,37 @@
 {% for key, data in brackets.items() %}
   <h2>Bracket {{ key }}</h2>
   <div class="ko-bracket">
-    {% for pairs in data.rounds %}
-      {% if pairs %}
+    {% for round in data.rounds %}
+      {% if round %}
       <div class="round">
-        {% for m in pairs %}
-        <div class="match">
-          <div class="player">{{ m[0].name }}</div>
-          <div class="player">{{ m[1].name }}</div>
-          <div class="result">
-            {% if m[2] %}
-              {% if m[2] == 'Draw' %}
-                Draw
-              {% else %}
-                {{ m[2].name }}
-              {% endif %}
-            {% else %}
-              <form method="post" action="/report_knockout_result">
-                <input type="hidden" name="bracket" value="{{ key }}">
-                <input type="hidden" name="player1" value="{{ m[0].id }}">
-                <input type="hidden" name="player2" value="{{ m[1].id }}">
-                <input type="number" name="score1" min="0" required>
-                <input type="number" name="score2" min="0" required>
-                <button type="submit">Submit</button>
-              </form>
+        {% for pair in round|batch(2, None) %}
+        <div class="pair">
+          {% for m in pair %}
+            {% if m %}
+            <div class="match">
+              <div class="player">{{ m[0].name }}</div>
+              <div class="player">{{ m[1].name }}</div>
+              <div class="result">
+                {% if m[2] %}
+                  {% if m[2] == 'Draw' %}
+                    Draw
+                  {% else %}
+                    {{ m[2].name }}
+                  {% endif %}
+                {% else %}
+                  <form method="post" action="/report_knockout_result">
+                    <input type="hidden" name="bracket" value="{{ key }}">
+                    <input type="hidden" name="player1" value="{{ m[0].id }}">
+                    <input type="hidden" name="player2" value="{{ m[1].id }}">
+                    <input type="number" name="score1" min="0" required>
+                    <input type="number" name="score2" min="0" required>
+                    <button type="submit">Submit</button>
+                  </form>
+                {% endif %}
+              </div>
+            </div>
             {% endif %}
-          </div>
+          {% endfor %}
         </div>
         {% endfor %}
       </div>


### PR DESCRIPTION
## Summary
- Restructure knockout bracket markup into paired matches for balanced layout
- Add CSS to draw connecting lines and center rounds for a symmetrical bracket

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895c7b1d25c832aa493d98ff1162b07