### PR TITLE
Highlight champion path in knockout bracket

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -242,6 +242,20 @@ body.dark-mode {
     margin-top: 0.5em;
 }
 
+.ko-bracket .match.winner-path {
+    border-color: gold;
+}
+
+.ko-bracket .match.winner-path .player {
+    color: gold;
+}
+
+.ko-bracket .pair.winner-path::before,
+.ko-bracket .pair.winner-path::after,
+.ko-bracket .match.winner-path::after {
+    border-color: gold;
+}
+
 .profile-layout {
     display: flex;
     gap: 1em;

--- a/templates/knockout.html
+++ b/templates/knockout.html
@@ -7,11 +7,11 @@
     {% for round in data.rounds %}
       {% if round %}
       <div class="round">
-        {% for pair in round|batch(2, None) %}
-        <div class="pair">
-          {% for m in pair %}
+        {% for pair in round %}
+        <div class="pair{% if pair.highlight %} winner-path{% endif %}">
+          {% for m in pair.matches %}
             {% if m %}
-            <div class="match">
+            <div class="match{% if m[3] %} winner-path{% endif %}">
               <div class="player">{{ m[0].name }}</div>
               <div class="player">{{ m[1].name }}</div>
               <div class="result">
@@ -41,8 +41,5 @@
       {% endif %}
     {% endfor %}
   </div>
-  {% if data.winner %}
-    <p class="champion">Winner: {{ data.winner.name }}</p>
-  {% endif %}
 {% endfor %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove redundant winner message below knockout bracket
- highlight champion's path in gold within the bracket

## Testing
- `python -m py_compile app.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895cb5e8414832a9de884e908cfcd14